### PR TITLE
Fix potential getcert/enroll SEGV

### DIFF
--- a/sscep.c
+++ b/sscep.c
@@ -866,7 +866,7 @@ not_enroll:
 			}
 			/* User supplied serial number */
 			if (s_flag) {
-				BIGNUM *bn;
+				BIGNUM *bn = NULL;
 				ASN1_INTEGER *ai;
 				int len = BN_dec2bn(&bn , s_char);
 				if (!len || !(ai = BN_to_ASN1_INTEGER(bn, NULL))) {


### PR DESCRIPTION
On my OpenSUSE 42.3 box with OpenSSL 1.0.2j plus engine_pkcs11 0.1.8,
"sscep getcert" crashed because of uninitialized BIGNUM bn.
